### PR TITLE
ManagementConnection - Added GetCimSession method

### DIFF
--- a/project/dbatools/Connection/ManagementConnection.cs
+++ b/project/dbatools/Connection/ManagementConnection.cs
@@ -1113,6 +1113,35 @@ namespace Dataplat.Dbatools.Connection
 
         #endregion DCOM
 
+        #region Shared
+        /// <summary>
+        /// Generates a CIM session to the target computer.
+        /// For use with other commands that expect a CIM session.
+        /// </summary>
+        /// <param name="Credential">Credential to use (if present)</param>
+        /// <returns>A CIM Session to the target computer represented by this connection.</returns>
+        /// <exception cref="Exception">When no CIM Session is available.</exception>
+        public CimSession GetCimSession(PSCredential Credential = null)
+        {
+            Exception tempError = null;
+            if ((DisabledConnectionTypes & ManagementConnectionType.CimRM) != ManagementConnectionType.CimRM)
+            {
+                try { return GetCimWinRMSession(Credential); }
+                catch (Exception e) { tempError = e; }
+            }
+
+            if ((DisabledConnectionTypes & ManagementConnectionType.CimDCOM) != ManagementConnectionType.CimDCOM)
+            {
+                try { return GetCimDComSession(Credential); }
+                catch (Exception e) { tempError = e; }
+            }
+
+            if (tempError != null)
+                throw tempError;
+            throw new Exception("No supporting connection type is enabled!");
+        }
+        #endregion Shared
+
         #endregion CIM Execution
 
         /// <summary>


### PR DESCRIPTION
This adds a `GetCimSession` method to the CM Connection class.

The key reason for this update is to improve interop between the read-only Computer Management component and the external use of `Invoke-CimMethod`. This enables the transparent passing through of session configurations and policies and will allow commands such as `Restart-DbaService` to respect proxy settings or protocol preference.

This includes the ability to execute against localhost without the WinRM Service running.

> Notes

+ As this only _adds_ a method without changing any existing code, this has no impact on anything (yet)
+ In order for this change to have an effect, it must then later be called from other functions in dbatools. But the library update should go first to avoid breaking tests, rather than updating the functions concurrently.