### PR TITLE
Add a win-sqlclient-x86 folder, in addition to win-sqlclient and copy certain files to there

### DIFF
--- a/build/build-core.ps1
+++ b/build/build-core.ps1
@@ -47,6 +47,7 @@ if ($IsLinux -or $IsMacOs) {
     $null = mkdir ./lib/win
     $null = mkdir ./lib/mac
     $null = mkdir ./lib/win-sqlclient
+    $null = mkdir ./lib/win-sqlclient-x86
 } else {
     $tempdir = "C:/temp"
     $null = New-Item -ItemType Directory $tempdir -ErrorAction Ignore
@@ -60,6 +61,7 @@ if ($IsLinux -or $IsMacOs) {
     $null = New-Item -ItemType Directory ./lib/win
     $null = New-Item -ItemType Directory ./lib/mac
     $null = New-Item -ItemType Directory ./lib/win-sqlclient
+    $null = New-Item -ItemType Directory ./lib/win-sqlclient-x86
 }
 
 
@@ -116,9 +118,16 @@ $parms.RequiredVersion = "4.53.0"
 $null = Install-Package @parms
 
 Copy-Item "$tempdir/nuget/Microsoft.Data.SqlClient.5.1.4/runtimes/unix/lib/net6.0/Microsoft.Data.SqlClient.dll" -Destination lib
+
+# Copy to the 'x64' directory
 Copy-Item "$tempdir/nuget/Microsoft.Data.SqlClient.5.1.4/runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll" -Destination lib/win-sqlclient/
 Copy-Item "$tempdir/nuget/Microsoft.Identity.Client.4.53.0/lib/net6.0/Microsoft.Identity.Client.dll" -Destination lib/win-sqlclient/ #Maybe this will be a problem, i dont know
 Copy-Item "$tempdir/nuget/Microsoft.Data.SqlClient.SNI.runtime.5.2.0/runtimes/win-x64/native/Microsoft.Data.SqlClient.SNI.dll" -Destination lib/win-sqlclient/
+
+# Copy to the 'x86' directory, but with a different SNI DLL file. Remember,the SNI file is not managed code, it's _native_.
+Copy-Item "$tempdir/nuget/Microsoft.Data.SqlClient.5.1.4/runtimes/win/lib/net6.0/Microsoft.Data.SqlClient.dll" -Destination lib/win-sqlclient-x86/
+Copy-Item "$tempdir/nuget/Microsoft.Identity.Client.4.53.0/lib/net6.0/Microsoft.Identity.Client.dll" -Destination lib/win-sqlclient-x86/ #Maybe this will be a problem, i dont know
+Copy-Item "$tempdir/nuget/Microsoft.Data.SqlClient.SNI.runtime.5.2.0/runtimes/win-x86/native/Microsoft.Data.SqlClient.SNI.dll" -Destination lib/win-sqlclient-x86/
 
 Copy-Item ./temp/linux/* -Destination lib -Exclude (Get-ChildItem lib -Recurse) -Recurse -Include *.exe, *.config -Verbose
 
@@ -131,7 +140,7 @@ $linux = 'libclrjit.so', 'libcoreclr.so', 'libhostfxr.so', 'libhostpolicy.so', '
 $sqlp = Get-ChildItem ./temp/linux/* -Exclude (Get-ChildItem lib -Recurse) | Where-Object Name -in $linux
 Copy-Item -Path $sqlp.FullName -Destination ./lib/
 
-Get-ChildItem -Directory -Path ./lib | Where-Object Name -notin 'win-sqlclient', 'x64', 'x86', 'win', 'mac', 'macos' | Remove-Item -Recurse
+Get-ChildItem -Directory -Path ./lib | Where-Object Name -notin 'win-sqlclient', 'win-sqlclient-x86', 'x64', 'x86', 'win', 'mac', 'macos' | Remove-Item -Recurse
 
 Get-ChildItem ./lib, ./lib/win, ./lib/mac | Where-Object BaseName -in (Get-ChildItem /opt/microsoft/powershell/7).BaseName -OutVariable files
 

--- a/dbatools.library.psm1
+++ b/dbatools.library.psm1
@@ -88,7 +88,12 @@ if ($PSVersionTable.PSEdition -ne "Core") {
 }
 
 if ($IsWindows -and $PSVersionTable.PSEdition -eq "Core") {
-    $sqlclient = [System.IO.Path]::Combine($script:libraryroot, "lib", "win-sqlclient", "Microsoft.Data.SqlClient.dll")
+    if ($env:PROCESSOR_ARCHITECTURE -eq "x86") {
+        $sqlclient = [System.IO.Path]::Combine($script:libraryroot, "lib", "win-sqlclient-x86", "Microsoft.Data.SqlClient.dll")
+    }
+    else {
+        $sqlclient = [System.IO.Path]::Combine($script:libraryroot, "lib", "win-sqlclient", "Microsoft.Data.SqlClient.dll")
+    }
 } else {
     $sqlclient = [System.IO.Path]::Combine($script:libraryroot, "lib", "Microsoft.Data.SqlClient.dll")
 }


### PR DESCRIPTION
If I have this fix right, it closes #10. 

I'm not sure if I have the build script perfect, in that I'm not 100% that the files I want will be copied when the Github build action runs. I just don't have a great way to test the build process, but I am only changing two files here and I'm only adding, not subtracting.

File #1: If you look at the PSM1 file, you can see that I am just adding a check (when we are running windows) to see if we are x86 or x86. I then choose a path (sql-winclient-x86 or sql-winclient) based on that.

File #2: If you look at build-core.ps1, you can see that I am creating sql-winclient-x86 in a way that mimics what was already there for sql-winclient (IOW both windows and non-windows), then copying three files into sql-winclient-x86. Two of the new files are identical to the ones found in sql-winclient, but the third is copied from the 'native x86' location the in the nupkg (which was already cracked open by pre-existing code in the build script). Anything else in there is basically "she does this for win-sqlclient, so we probably need it for win-sqlclient-x86 too".

I did hand-build a version on my laptop ("2024.4.99", so I can test auto import). It works as I expected it to. So, "it works on my machine", but we all know how that goes. I will probably go ahead and deploy this in my estate on at least one production machine where I have a particularly thorny problem. When the official version gets released with a new version number, my version will be automatically superseded.
