### PR TITLE
Fix import failure on some PowerShell Core installs by adjusting `System.Management.Automation` references and target frameworks

### DIFF
--- a/dbatools.library.psd1
+++ b/dbatools.library.psd1
@@ -7,7 +7,7 @@
 #
 @{
     # Version number of this module.
-    ModuleVersion          = '2025.7.20'
+    ModuleVersion          = '2025.7.28'
 
     # ID used to uniquely identify this module
     GUID                   = '00b61a37-6c36-40d8-8865-ac0180288c84'

--- a/dbatools.library.psd1
+++ b/dbatools.library.psd1
@@ -7,7 +7,7 @@
 #
 @{
     # Version number of this module.
-    ModuleVersion          = '2025.7.28'
+    ModuleVersion          = '2025.8.1'
 
     # ID used to uniquely identify this module
     GUID                   = '00b61a37-6c36-40d8-8865-ac0180288c84'
@@ -19,7 +19,7 @@
     CompanyName            = 'dbatools.io'
 
     # Copyright statement for this module
-    Copyright              = 'Copyright (c) 2024 by dbatools, licensed under MIT'
+    Copyright              = 'Copyright (c) 2025 by dbatools, licensed under MIT'
 
     # Description of the functionality provided by this module
     Description            = 'The library that powers dbatools, the community module for SQL Server Pros'

--- a/project/dbatools/dbatools.csproj
+++ b/project/dbatools/dbatools.csproj
@@ -60,8 +60,8 @@
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.7" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="System.Management.Automation" Version="7.4.11" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/project/dbatools/dbatools.csproj
+++ b/project/dbatools/dbatools.csproj
@@ -51,20 +51,24 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
+  <!-- Shared packages for both frameworks -->
   <ItemGroup>
     <PackageReference Include="Microsoft.AnalysisServices" Version="19.101.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
     <PackageReference Include="Microsoft.SqlServer.DacFx" Version="170.0.94" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="172.76.0" />
     <PackageReference Include="Microsoft.SqlServer.XEvent.XELite" Version="2024.2.5.1" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.7" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" PrivateAssets="all" />
-  </ItemGroup>
-
+  <!-- Framework-specific packages -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
   </ItemGroup>
 
@@ -77,7 +81,7 @@
     </Reference>
   </ItemGroup>
 
-  <!-- Linux/non-Windows PowerShell SDK reference for net472 -->
+  <!-- Linux/non-Windows PowerShell reference for net472 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' AND '$(OS)' != 'Windows_NT'">
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
   </ItemGroup>


### PR DESCRIPTION
This PR resolves **#9712**, which caused `Import-Module dbatools` to fail on systems running **PowerShell Core <7.4.6** due to a hardcoded reference to `System.Management.Automation` **v7.4.6.500**, which may not exist in the user's environment.

---

### 🔧 Problem

Users reported module load errors like:

```
Could not load file or assembly 'System.Management.Automation, Version=7.4.6.500, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
```

This was caused by a static reference to `System.Management.Automation` that was not compatible with lower versions of PowerShell 7.4.

---

### ✅ Fix

* Updated `dbatools.csproj` to:

  * Remove shared reference to `System.Threading.Tasks.Dataflow`
  * Use **framework-specific dependencies**:

    * `net472` gets `System.Threading.Tasks.Dataflow` v6.0.0
    * `net8.0` gets v8.0.1
  * Add `Microsoft.PowerShell.SDK` v7.4.0 as a **private asset** to support flexible loading of `System.Management.Automation` in `net8.0` targets without forcing a specific patch version.

* Updated `dbatools.library.psd1` to:

  * Bump version from `2025.7.20` to `2025.7.28`

* Improved project comments to clarify reasoning behind multi-targeted package references.

---

### 🧪 Tested Scenarios

* PowerShell Core 7.4.1 and 7.4.6
* Verified load behavior across containers and clean installs
* Reproduced issue using `mcr.microsoft.com/azuredeploymentscripts-powershell:az10.0`
* Confirmed fix using manually loaded preview builds (v2025.7.25, v2025.7.29)

---

### 🙌 Thanks

Special thanks to @saxet77, @onutu, and @d3m1sc0 for detailed logs, testing, and persistence in reproducing and verifying the issue and fix.
