### PR TITLE
Remove XESmartTarget Commands and Fix DAC

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -201,6 +201,13 @@ jobs:
             New-Item -ItemType Directory -Path /tmp/DbatoolsExport -Force | Out-Null
           }
 
+      - name: Install SqlPackage and XESmartTarget for DAC tests
+        run: |
+          Import-Module ./artifacts/dbatools.library/dbatools.library.psd1 -Force
+          Import-Module ./dbatools/dbatools.psd1 -Force
+          Install-DbaSqlPackage -Verbose
+          Install-DbaXESmartTarget -Force
+
       - name: Debug working directory
         shell: pwsh
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -202,6 +202,7 @@ jobs:
           }
 
       - name: Install SqlPackage and XESmartTarget for DAC tests
+        shell: pwsh
         run: |
           Import-Module ./artifacts/dbatools.library/dbatools.library.psd1 -Force
           Import-Module ./dbatools/dbatools.psd1 -Force

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -201,13 +201,12 @@ jobs:
             New-Item -ItemType Directory -Path /tmp/DbatoolsExport -Force | Out-Null
           }
 
-      - name: Install SqlPackage and XESmartTarget for DAC tests
+      - name: Install SqlPackagetests
         shell: pwsh
         run: |
           Import-Module ./artifacts/dbatools.library/dbatools.library.psd1 -Force
           Import-Module ./dbatools/dbatools.psd1 -Force
           Install-DbaSqlPackage -Verbose
-          Install-DbaXESmartTarget -Force
 
       - name: Debug working directory
         shell: pwsh

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,13 +73,6 @@ jobs:
         shell: pwsh
         run: .\build\build.ps1 -BuildZip
 
-      - name: Make sqlpackage executable
-        if: runner.os != 'Windows'
-        shell: pwsh
-        run: |
-          chmod +x ./artifacts/dbatools.library/core/lib/dac/linux/sqlpackage || true
-          chmod +x ./artifacts/dbatools.library/core/lib/dac/mac/sqlpackage || true
-
       - name: Verify critical files
         shell: pwsh
         run: |
@@ -87,12 +80,9 @@ jobs:
           $criticalPaths = @(
             "desktop/lib",
             "desktop/lib/runtimes/win-x64/native",
-            "core/lib/dac/windows",
             "desktop/third-party",
             "core/lib",
             "core/lib/runtimes/win-x64/native",
-            "core/lib/dac/linux",
-            "core/lib/dac/mac",
             "core/third-party"
           )
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,6 @@ jobs:
       shell: pwsh
       run: |
         Copy-Item -Path artifacts/core-lib-linux/* -Destination artifacts/dbatools.library/core/lib/ -Recurse -Force
-        # delete windows sqlpackage on core cuz its the same as desktop
-        Remove-Item -Path artifacts/dbatools.library/core/lib/dac/windows -Recurse -Force -ErrorAction Ignore
 
     - name: Verify critical files and directories
       shell: pwsh
@@ -74,13 +72,10 @@ jobs:
         $artifactsDir = "./artifacts/dbatools.library"
         $criticalPaths = @(
           "desktop\lib",
-          "desktop\lib\dac",
           "desktop\lib\runtimes\win-x64\native",
           "desktop\third-party",
           "core\lib",
           "core\lib\runtimes\win-x64\native",
-          "core\lib\dac\linux",
-          "core\lib\dac\mac",
           "core\third-party"
         )
 

--- a/dbatools.library.psd1
+++ b/dbatools.library.psd1
@@ -7,7 +7,7 @@
 #
 @{
     # Version number of this module.
-    ModuleVersion          = '2025.8.5'
+    ModuleVersion          = '2025.8.17'
 
     # ID used to uniquely identify this module
     GUID                   = '00b61a37-6c36-40d8-8865-ac0180288c84'


### PR DESCRIPTION
Too much mixing and matching of DLLs as well as a new distribution of XESmartTarget that does not include the DLLs.

Happy for anyone to take the removed commands and make it a separate module that can be hosted on the dataplat org. I imagine it would require manual clones and builds of the package with manual extraction of the DLLs.

@spaghettidba no action needed just wanted to give a heads up.