### PR TITLE
Fix: Allow dashes in SQL Server instance names

### DIFF
--- a/project/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
+++ b/project/dbatools.Tests/Parameter/DbaInstanceParamaterTest.cs
@@ -202,5 +202,41 @@ namespace Dataplat.Dbatools.Parameter
             Assert.AreEqual(SqlConnectionProtocol.Any, dbaInstanceParamater.NetworkProtocol);
             Assert.IsTrue(dbaInstanceParamater.IsLocalHost);
         }
+
+        /// <summary>
+        /// Checks that instance names with dashes are properly parsed
+        /// </summary>
+        [TestMethod]
+        public void TestInstanceNameWithDash()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter("My-Instance.domain.local\\My-TestInstance");
+
+            Assert.AreEqual("My-Instance.domain.local", dbaInstanceParamater.ComputerName);
+            Assert.AreEqual("My-TestInstance", dbaInstanceParamater.InstanceName);
+            Assert.AreEqual("My-Instance.domain.local\\My-TestInstance", dbaInstanceParamater.FullName);
+            Assert.AreEqual("My-Instance.domain.local\\My-TestInstance", dbaInstanceParamater.FullSmoName);
+            Assert.AreEqual("[My-Instance.domain.local]", dbaInstanceParamater.SqlComputerName);
+            Assert.AreEqual("[My-TestInstance]", dbaInstanceParamater.SqlInstanceName);
+            Assert.AreEqual("[My-Instance.domain.local\\My-TestInstance]", dbaInstanceParamater.SqlFullName);
+            Assert.IsFalse(dbaInstanceParamater.IsConnectionString);
+        }
+
+        /// <summary>
+        /// Checks that server names with dashes work correctly (regression test)
+        /// </summary>
+        [TestMethod]
+        public void TestServerNameWithDash()
+        {
+            var dbaInstanceParamater = new DbaInstanceParameter("My-Instance.domain.local\\MyTestInstance");
+
+            Assert.AreEqual("My-Instance.domain.local", dbaInstanceParamater.ComputerName);
+            Assert.AreEqual("MyTestInstance", dbaInstanceParamater.InstanceName);
+            Assert.AreEqual("My-Instance.domain.local\\MyTestInstance", dbaInstanceParamater.FullName);
+            Assert.AreEqual("My-Instance.domain.local\\MyTestInstance", dbaInstanceParamater.FullSmoName);
+            Assert.AreEqual("[My-Instance.domain.local]", dbaInstanceParamater.SqlComputerName);
+            Assert.AreEqual("[MyTestInstance]", dbaInstanceParamater.SqlInstanceName);
+            Assert.AreEqual("[My-Instance.domain.local\\MyTestInstance]", dbaInstanceParamater.SqlFullName);
+            Assert.IsFalse(dbaInstanceParamater.IsConnectionString);
+        }
     }
 }

--- a/project/dbatools/Utility/RegexHelper.cs
+++ b/project/dbatools/Utility/RegexHelper.cs
@@ -53,12 +53,12 @@
         /// <summary>
         /// Will match a mostly valid instance name.
         /// </summary>
-        public static string InstanceName = @"^[\p{L}&_#][\p{L}\d\$#_]{0,15}$";
+        public static string InstanceName = @"^[\p{L}&_#][\p{L}\d\$#_\-]{0,15}$";
 
         /// <summary>
         /// Will match any instance of a mostly valid instance name.
         /// </summary>
-        public static string InstanceNameEx = @"[\p{L}&_#][\p{L}\d\$#_]{0,15}";
+        public static string InstanceNameEx = @"[\p{L}&_#][\p{L}\d\$#_\-]{0,15}";
 
         /// <summary>
         /// Matches a word against the list of officially reserved keywords


### PR DESCRIPTION
## Summary

Fixed the issue where SQL Server instance names containing dashes were incorrectly rejected as invalid.

## Changes

- Updated `InstanceName` and `InstanceNameEx` regex patterns to include the dash/hyphen character
- Added test cases to verify instance names with dashes work correctly

## Details

The regex pattern in `RegexHelper.cs` was missing the dash character which is valid in SQL Server instance names according to Microsoft documentation. Instance names like `My-TestInstance` now parse correctly.

Fixes #13

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/dataplat/dbatools.library/tree/claude/issue-13-20251102-2021) | [View job run](https://github.com/dataplat/dbatools.library/actions/runs/19017646140