### PR TITLE
Make Get-DbaConnectedInstance see explicit-Windows-credential connections

### DIFF
--- a/project/Dataplat.Dbatools.Csv/Dataplat.Dbatools.Csv.csproj
+++ b/project/Dataplat.Dbatools.Csv/Dataplat.Dbatools.Csv.csproj
@@ -7,7 +7,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>Dataplat.Dbatools.Csv</PackageId>
-    <Version>1.1.17</Version>
+    <Version>1.1.18</Version>
     <Authors>Chrissy LeMaire</Authors>
     <Company>Dataplat</Company>
     <Product>Dataplat.Dbatools.Csv</Product>

--- a/project/dbatools.Tests/Connection/ConnectionServiceRegisterConnectionTest.cs
+++ b/project/dbatools.Tests/Connection/ConnectionServiceRegisterConnectionTest.cs
@@ -5,6 +5,9 @@ using Dataplat.Dbatools.Message;
 using Microsoft.Data.SqlClient;
 using Microsoft.SqlServer.Management.Smo;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if NET8_0_OR_GREATER
+using System.Net;
+#endif
 using DbaMessageLevel = Dataplat.Dbatools.Message.MessageLevel;
 
 namespace Dataplat.Dbatools.Connection.Test
@@ -257,5 +260,59 @@ namespace Dataplat.Dbatools.Connection.Test
                 }
             }
         }
+
+        [TestMethod]
+        public void GetRegistryKey_WithoutSspiProvider_ReturnsConnectionStringUnchanged()
+        {
+            string key = UniqueKey();
+            Assert.AreEqual(key, ConnectionService.GetRegistryKey(key, new SqlConnection()));
+        }
+
+#if NET8_0_OR_GREATER
+        [TestMethod]
+        public void GetRegistryKey_WithSspiProvider_AppendsPrincipal()
+        {
+            string key = UniqueKey();
+            using (SqlConnection connection = new SqlConnection())
+            using (NetworkCredentialSspiContextProvider provider = new NetworkCredentialSspiContextProvider(
+                new NetworkCredential("user", "password", "domain")))
+            {
+                connection.SspiContextProvider = provider;
+                Assert.AreEqual(key + "|sspi:domain\\user", ConnectionService.GetRegistryKey(key, connection));
+            }
+        }
+
+        [TestMethod]
+        public void RegisterConnection_DifferentSspiIdentitiesDoNotCollide()
+        {
+            // Root-cause regression test for the Get-DbaConnectedInstance visibility gap:
+            // an explicit Windows credential lives out-of-band on SspiContextProvider, not in
+            // the connection string, so two different identities against the same connection
+            // string must land in two separate ActiveConnections entries instead of one
+            // silently clobbering the other.
+            string key = UniqueKey();
+            using (SqlConnection first = new SqlConnection())
+            using (SqlConnection second = new SqlConnection())
+            using (NetworkCredentialSspiContextProvider firstProvider = new NetworkCredentialSspiContextProvider(
+                new NetworkCredential("first-user", "password", "domain")))
+            using (NetworkCredentialSspiContextProvider secondProvider = new NetworkCredentialSspiContextProvider(
+                new NetworkCredential("second-user", "password", "domain")))
+            {
+                first.SspiContextProvider = firstProvider;
+                second.SspiContextProvider = secondProvider;
+
+                ConnectionService.RegisterConnection(key, first, null);
+                ConnectionService.RegisterConnection(key, second, null);
+
+                string firstKey = ConnectionService.GetRegistryKey(key, first);
+                string secondKey = ConnectionService.GetRegistryKey(key, second);
+
+                Assert.AreNotEqual(firstKey, secondKey);
+                Assert.AreSame(first, ConnectionHost.ActiveConnections[firstKey][0]);
+                Assert.AreSame(second, ConnectionHost.ActiveConnections[secondKey][0]);
+                Assert.IsFalse(ConnectionHost.ActiveConnections.ContainsKey(key));
+            }
+        }
+#endif
     }
 }

--- a/project/dbatools.Tests/Connection/SqlClientCompatibilityTest.cs
+++ b/project/dbatools.Tests/Connection/SqlClientCompatibilityTest.cs
@@ -41,6 +41,19 @@ namespace Dataplat.Dbatools.Connection
         }
 
         [TestMethod]
+        public void NetworkCredentialSspiProviderExposesPasswordFreePrincipal()
+        {
+            using (NetworkCredentialSspiContextProvider domainQualified = new NetworkCredentialSspiContextProvider(
+                new NetworkCredential("user", "password", "domain")))
+            using (NetworkCredentialSspiContextProvider domainless = new NetworkCredentialSspiContextProvider(
+                new NetworkCredential("user", "password", string.Empty)))
+            {
+                Assert.AreEqual("domain\\user", domainQualified.Principal);
+                Assert.AreEqual("user", domainless.Principal);
+            }
+        }
+
+        [TestMethod]
         public void NetworkCredentialSspiProviderHasStablePoolIdentityPerCredential()
         {
             using (NetworkCredentialSspiContextProvider first = new NetworkCredentialSspiContextProvider(

--- a/project/dbatools.core/Commands/ConnectDbaInstanceCommand.Processing.cs
+++ b/project/dbatools.core/Commands/ConnectDbaInstanceCommand.Processing.cs
@@ -139,7 +139,13 @@ public sealed partial class ConnectDbaInstanceCommand
 
             if (resolution.IsNewConnection && !DedicatedAdminConnection)
             {
-                ConnectionService.RegisterInstanceForTepp(resolution.Instance, resolution.Server);
+                // RegisterInstanceForTepp copies ConnectionContext for the TEPP cache, which
+                // would silently drop an explicit-Windows-credential SspiContextProvider and
+                // reintroduce the identity-loss bug this connection type exists to avoid.
+                if (!resolution.UsesCredentialSspiProvider)
+                {
+                    ConnectionService.RegisterInstanceForTepp(resolution.Instance, resolution.Server);
+                }
 
                 // Update lots of registered stuff
                 // Default for [Dataplat.Dbatools.TabExpansion.TabExpansionHost]::TeppSyncDisabled is $true, so will not run by default

--- a/project/dbatools.core/Commands/DisconnectDbaInstanceCommand.cs
+++ b/project/dbatools.core/Commands/DisconnectDbaInstanceCommand.cs
@@ -76,10 +76,10 @@ public sealed class DisconnectDbaInstanceCommand : DbaBaseCmdlet
 
                             // PS: registry lookup, removal, and the masked output each read
                             // $server.ConnectionContext.ConnectionString AGAIN.
-                            if (RegistryEntryIsTruthy(ToPsString(PsProperty.Get(PsProperty.Get(server, "ConnectionContext"), "ConnectionString"))))
+                            if (RegistryEntryIsTruthy(RegistryKeyFor(server, ToPsString(PsProperty.Get(PsProperty.Get(server, "ConnectionContext"), "ConnectionString")))))
                             {
                                 WriteMessage(MessageLevel.Verbose, "removing from connection hash");
-                                RemoveRegistryEntry(ToPsString(PsProperty.Get(PsProperty.Get(server, "ConnectionContext"), "ConnectionString")));
+                                RemoveRegistryEntry(RegistryKeyFor(server, ToPsString(PsProperty.Get(PsProperty.Get(server, "ConnectionContext"), "ConnectionString"))));
                             }
 
                             PSObject result = new PSObject();
@@ -107,10 +107,10 @@ public sealed class DisconnectDbaInstanceCommand : DbaBaseCmdlet
                                 InvokePsMethod(server, "Close");
                             }
 
-                            if (RegistryEntryIsTruthy(ToPsString(PsProperty.Get(server, "ConnectionString"))))
+                            if (RegistryEntryIsTruthy(RegistryKeyFor(server, ToPsString(PsProperty.Get(server, "ConnectionString")))))
                             {
                                 WriteMessage(MessageLevel.Verbose, "removing from connection hash");
-                                RemoveRegistryEntry(ToPsString(PsProperty.Get(server, "ConnectionString")));
+                                RemoveRegistryEntry(RegistryKeyFor(server, ToPsString(PsProperty.Get(server, "ConnectionString"))));
                             }
 
                             PSObject result = new PSObject();
@@ -162,6 +162,26 @@ public sealed class DisconnectDbaInstanceCommand : DbaBaseCmdlet
             return null;
         }
         return (string)LanguagePrimitives.ConvertTo(value, typeof(string), CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// The key ConnectionHost.ActiveConnections was actually registered under for this
+    /// connection object — see ConnectionService.GetRegistryKey. An explicit-Windows-credential
+    /// connection is keyed by connection string plus Windows principal (not the raw connection
+    /// string alone), since the credential lives out-of-band on SspiContextProvider.
+    /// </summary>
+    private static string? RegistryKeyFor(object? server, string? connectionString)
+    {
+        if (connectionString is null)
+        {
+            return null;
+        }
+        if (server is null)
+        {
+            return connectionString;
+        }
+        object baseServer = server is PSObject wrapped ? wrapped.BaseObject : server;
+        return ConnectionService.GetRegistryKey(connectionString, baseServer);
     }
 
     /// <summary>

--- a/project/dbatools.core/Commands/GetDbaConnectedInstanceCommand.cs
+++ b/project/dbatools.core/Commands/GetDbaConnectedInstanceCommand.cs
@@ -245,14 +245,25 @@ public sealed class GetDbaConnectedInstanceCommand : DbaBaseCmdlet
     // present, or the fixed failure string when the key does not parse as a connection string.
     private static string HideConnectionString(string connectionString)
     {
+        // Explicit-Windows-credential entries carry a "|sspi:<principal>" suffix appended by
+        // ConnectionService.GetRegistryKey to keep ActiveConnections keys collision-free; the
+        // principal isn't secret, so it's preserved rather than parsed as part of the DSN.
+        string dsn = connectionString;
+        string suffix = string.Empty;
+        int sspiIndex = connectionString.IndexOf("|sspi:", StringComparison.Ordinal);
+        if (sspiIndex >= 0)
+        {
+            dsn = connectionString.Substring(0, sspiIndex);
+            suffix = connectionString.Substring(sspiIndex);
+        }
         try
         {
-            Microsoft.Data.SqlClient.SqlConnectionStringBuilder builder = new(connectionString);
+            Microsoft.Data.SqlClient.SqlConnectionStringBuilder builder = new(dsn);
             if (!string.IsNullOrEmpty(builder.Password))
             {
                 builder.Password = "********";
             }
-            return builder.ConnectionString;
+            return builder.ConnectionString + suffix;
         }
         catch
         {

--- a/project/dbatools/Connection/ConnectionService.InitFields.cs
+++ b/project/dbatools/Connection/ConnectionService.InitFields.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Specialized;
+using Dataplat.Dbatools.Message;
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Dataplat.Dbatools.Connection
+{
+    public static partial class ConnectionService
+    {
+        #region SetDefaultInitFields priming
+        //'PrimaryFilePath' seems the culprit for slow SMO on databases
+        private static readonly string[] Fields2000_Db = new string[] { "Collation", "CompatibilityLevel", "CreateDate", "ID", "IsAccessible", "IsFullTextEnabled", "IsSystemObject", "IsUpdateable", "LastBackupDate", "LastDifferentialBackupDate", "LastLogBackupDate", "Name", "Owner", "ReadOnly", "RecoveryModel", "ReplicationOptions", "Status", "Version" };
+        private static readonly string[] Fields200x_Db = new string[] { "Collation", "CompatibilityLevel", "CreateDate", "ID", "IsAccessible", "IsFullTextEnabled", "IsSystemObject", "IsUpdateable", "LastBackupDate", "LastDifferentialBackupDate", "LastLogBackupDate", "Name", "Owner", "ReadOnly", "RecoveryModel", "ReplicationOptions", "Status", "Version", "BrokerEnabled", "DatabaseSnapshotBaseName", "IsMirroringEnabled", "Trustworthy" };
+        private static readonly string[] Fields201x_Db = new string[] { "Collation", "CompatibilityLevel", "CreateDate", "ID", "IsAccessible", "IsFullTextEnabled", "IsSystemObject", "IsUpdateable", "LastBackupDate", "LastDifferentialBackupDate", "LastLogBackupDate", "Name", "Owner", "ReadOnly", "RecoveryModel", "ReplicationOptions", "Status", "Version", "BrokerEnabled", "DatabaseSnapshotBaseName", "IsMirroringEnabled", "Trustworthy", "ActiveConnections", "AvailabilityDatabaseSynchronizationState", "AvailabilityGroupName", "ContainmentType", "EncryptionEnabled" };
+
+        private static readonly string[] Fields2000_Login = new string[] { "CreateDate", "DateLastModified", "DefaultDatabase", "DenyWindowsLogin", "IsSystemObject", "Language", "LanguageAlias", "LoginType", "Name", "Sid", "WindowsLoginAccessType" };
+        private static readonly string[] Fields200x_Login = new string[] { "CreateDate", "DateLastModified", "DefaultDatabase", "DenyWindowsLogin", "IsSystemObject", "Language", "LanguageAlias", "LoginType", "Name", "Sid", "WindowsLoginAccessType", "AsymmetricKey", "Certificate", "Credential", "ID", "IsDisabled", "IsLocked", "IsPasswordExpired", "MustChangePassword", "PasswordExpirationEnabled", "PasswordPolicyEnforced" };
+        private static readonly string[] Fields201x_Login = new string[] { "CreateDate", "DateLastModified", "DefaultDatabase", "DenyWindowsLogin", "IsSystemObject", "Language", "LanguageAlias", "LoginType", "Name", "Sid", "WindowsLoginAccessType", "AsymmetricKey", "Certificate", "Credential", "ID", "IsDisabled", "IsLocked", "IsPasswordExpired", "MustChangePassword", "PasswordExpirationEnabled", "PasswordPolicyEnforced", "PasswordHashAlgorithm" };
+
+        //see #7753
+        private static readonly string[] Fields_Job = new string[] { "LastRunOutcome", "CurrentRunStatus", "CurrentRunStep", "CurrentRunRetryAttempt", "NextRunScheduleID", "NextRunDate", "LastRunDate", "JobType", "HasStep", "HasServer", "CurrentRunRetryAttempt", "HasSchedule", "Category", "CategoryID", "CategoryType", "OperatorToEmail", "OperatorToNetSend", "OperatorToPage" };
+
+        private static int _loadedSmoMajorVersion = -1;
+
+        private static int GetLoadedSmoMajorVersion()
+        {
+            // PS begin block: $loadedSmoVersion from the loaded Microsoft.SqlServer.SMO
+            // assembly's location/ProductVersion, later compared -ge 11. The compiled port
+            // links the vendored SMO directly (file version 18.x for SqlManagementObjects
+            // 181.x), so this resolves once and stays.
+            if (_loadedSmoMajorVersion < 0)
+            {
+                try
+                {
+                    string location = typeof(Server).Assembly.Location;
+                    System.Diagnostics.FileVersionInfo info = System.Diagnostics.FileVersionInfo.GetVersionInfo(location);
+                    _loadedSmoMajorVersion = info.ProductMajorPart;
+                }
+                catch
+                {
+                    // Single-file or reflection-restricted hosts: the linked SMO is modern.
+                    _loadedSmoMajorVersion = 18;
+                }
+            }
+            return _loadedSmoMajorVersion;
+        }
+
+        /// <summary>
+        /// The SetDefaultInitFields priming of Connect-DbaInstance.ps1, with the exact
+        /// per-version field lists (BP-201/BP-202).
+        /// </summary>
+        /// <param name="server">The connected server</param>
+        /// <param name="isAzure">Whether the target is Azure (skips priming)</param>
+        /// <param name="messageCallback">Optional verbatim-message sink</param>
+        public static void ApplyDefaultInitFields(Server server, bool isAzure, Action<MessageLevel, string> messageCallback)
+        {
+            // By default, SMO initializes several properties. We push it to the limit and gather a bit more
+            // this slows down the connect a smidge but drastically improves overall performance
+            // especially when dealing with a multitude of servers
+            if (GetLoadedSmoMajorVersion() >= 11 && !isAzure)
+            {
+                try
+                {
+                    if (messageCallback != null)
+                        messageCallback(MessageLevel.Debug, "SetDefaultInitFields will be used");
+                    StringCollection initFieldsDb = new StringCollection();
+                    StringCollection initFieldsLogin = new StringCollection();
+                    StringCollection initFieldsJob = new StringCollection();
+                    if (server.VersionMajor == 8)
+                    {
+                        // 2000
+                        initFieldsDb.AddRange(Fields2000_Db);
+                        initFieldsLogin.AddRange(Fields2000_Login);
+                    }
+                    else if (server.VersionMajor == 9 || server.VersionMajor == 10)
+                    {
+                        // 2005 and 2008
+                        initFieldsDb.AddRange(Fields200x_Db);
+                        initFieldsLogin.AddRange(Fields200x_Login);
+                    }
+                    else if (server.VersionMajor >= 16)
+                    {
+                        // 2022 and above - exclude ActiveConnections due to performance issue #9282
+                        foreach (string field in Fields201x_Db)
+                        {
+                            if (!String.Equals(field, "ActiveConnections", StringComparison.Ordinal))
+                                initFieldsDb.Add(field);
+                        }
+                        initFieldsLogin.AddRange(Fields201x_Login);
+                    }
+                    else
+                    {
+                        // 2012 to 2019
+                        initFieldsDb.AddRange(Fields201x_Db);
+                        initFieldsLogin.AddRange(Fields201x_Login);
+                    }
+                    server.SetDefaultInitFields(typeof(Microsoft.SqlServer.Management.Smo.Database), initFieldsDb);
+                    server.SetDefaultInitFields(typeof(Microsoft.SqlServer.Management.Smo.Login), initFieldsLogin);
+                    //see 7753
+                    initFieldsJob.AddRange(Fields_Job);
+                    server.SetDefaultInitFields(typeof(Microsoft.SqlServer.Management.Smo.Agent.Job), initFieldsJob);
+                }
+                catch (Exception ex)
+                {
+                    if (messageCallback != null)
+                        messageCallback(MessageLevel.Debug, String.Format("SetDefaultInitFields failed with {0}", ex.Message));
+                    // perhaps a DLL issue, continue going
+                }
+            }
+        }
+        #endregion SetDefaultInitFields priming
+    }
+}

--- a/project/dbatools/Connection/ConnectionService.Registry.cs
+++ b/project/dbatools/Connection/ConnectionService.Registry.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using Dataplat.Dbatools.Message;
+#if NET8_0_OR_GREATER
+using Microsoft.Data.SqlClient;
+#endif
+using Microsoft.SqlServer.Management.Smo;
+
+namespace Dataplat.Dbatools.Connection
+{
+    public static partial class ConnectionService
+    {
+        /// <summary>
+        /// private/functions/Add-ConnectionHashValue.ps1 parity over
+        /// ConnectionHost.ActiveConnections: non-pooled connections append to the entry's
+        /// list, pooled connections replace it. The dictionary key is GetRegistryKey's
+        /// result, not the raw connection string, so explicit-Windows-credential
+        /// connections do not collide with each other.
+        /// </summary>
+        /// <param name="key">The connection string key</param>
+        /// <param name="value">The Server or SqlConnection to register</param>
+        /// <param name="messageCallback">Optional verbatim-message sink</param>
+        public static void RegisterConnection(string key, object value, Action<MessageLevel, string> messageCallback)
+        {
+            if (messageCallback != null)
+                messageCallback(MessageLevel.Debug, "Adding to connection hash");
+            if (String.IsNullOrEmpty(key) || value == null)
+                return;
+
+            string registryKey = GetRegistryKey(key, value);
+
+            // PS: if ($Value.ConnectionContext.NonPooledConnection -or $Value.NonPooledConnection)
+            // A Server exposes it through ConnectionContext; a bare SqlConnection has neither,
+            // which lands in the pooled/replace branch exactly like the PS member miss did.
+            bool nonPooled = false;
+            Server serverValue = value as Server;
+            if (serverValue != null)
+            {
+                try { nonPooled = serverValue.ConnectionContext.NonPooledConnection; }
+                catch { /* unreadable on some connection shapes; treat as pooled like the PS member miss */ }
+            }
+
+            lock (ConnectionHost.ActiveConnections)
+            {
+                if (nonPooled)
+                {
+                    List<object> entries;
+                    if (!ConnectionHost.ActiveConnections.TryGetValue(registryKey, out entries) || entries == null)
+                    {
+                        entries = new List<object>();
+                        ConnectionHost.ActiveConnections[registryKey] = entries;
+                    }
+                    entries.Add(value);
+                }
+                else
+                {
+                    List<object> single = new List<object>();
+                    single.Add(value);
+                    ConnectionHost.ActiveConnections[registryKey] = single;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds the ConnectionHost.ActiveConnections key for a connection: the raw
+        /// connection string, unless the connection authenticates through a
+        /// NetworkCredentialSspiContextProvider, in which case the Windows principal is
+        /// appended. An explicit Windows credential lives out-of-band on
+        /// SqlConnection.SspiContextProvider rather than in the connection string, so two
+        /// different identities against the same server/database would otherwise collide on
+        /// the same dictionary key and silently clobber each other's registration.
+        /// Get-DbaConnectedInstance and Disconnect-DbaInstance call this to look up and
+        /// remove entries with the same key a registration used.
+        /// </summary>
+        /// <param name="connectionString">The raw connection string</param>
+        /// <param name="value">The Server or SqlConnection being registered or looked up</param>
+        public static string GetRegistryKey(string connectionString, object value)
+        {
+#if NET8_0_OR_GREATER
+            NetworkCredentialSspiContextProvider provider = GetSspiProvider(value);
+            if (provider != null)
+                return connectionString + "|sspi:" + provider.Principal;
+#endif
+            return connectionString;
+        }
+
+#if NET8_0_OR_GREATER
+        private static NetworkCredentialSspiContextProvider GetSspiProvider(object value)
+        {
+            SqlConnection sqlConnection = value as SqlConnection;
+            if (sqlConnection == null)
+            {
+                Server server = value as Server;
+                if (server == null)
+                    return null;
+                try { sqlConnection = server.ConnectionContext.SqlConnectionObject; }
+                catch { return null; }
+            }
+            return sqlConnection == null ? null : sqlConnection.SspiContextProvider as NetworkCredentialSspiContextProvider;
+        }
+#endif
+    }
+}

--- a/project/dbatools/Connection/ConnectionService.Verify.cs
+++ b/project/dbatools/Connection/ConnectionService.Verify.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Text.RegularExpressions;
 using Dataplat.Dbatools.Message;
@@ -136,8 +135,7 @@ namespace Dataplat.Dbatools.Connection
 
             if (request.SqlConnectionOnly)
             {
-                if (!state.UsesCredentialSspiProvider)
-                    RegisterConnection(server.ConnectionContext.ConnectionString, server.ConnectionContext.SqlConnectionObject, request.MessageCallback);
+                RegisterConnection(server.ConnectionContext.ConnectionString, server.ConnectionContext.SqlConnectionObject, request.MessageCallback);
                 Msg(request, MessageLevel.Debug, "We return only SqlConnection in server.ConnectionContext.SqlConnectionObject");
                 resolution.SqlConnection = server.ConnectionContext.SqlConnectionObject;
                 return resolution;
@@ -254,8 +252,7 @@ namespace Dataplat.Dbatools.Connection
                     RegisterInstanceForTepp(resolution.Instance, resolution.Server);
                 ApplyDefaultInitFields(resolution.Server, resolution.IsAzure, request.MessageCallback);
             }
-            if (!resolution.UsesCredentialSspiProvider)
-                RegisterConnection(resolution.Server.ConnectionContext.ConnectionString, resolution.Server, request.MessageCallback);
+            RegisterConnection(resolution.Server.ConnectionContext.ConnectionString, resolution.Server, request.MessageCallback);
         }
 
         /// <summary>
@@ -302,154 +299,5 @@ namespace Dataplat.Dbatools.Connection
             }
         }
 
-        #region SetDefaultInitFields priming
-        //'PrimaryFilePath' seems the culprit for slow SMO on databases
-        private static readonly string[] Fields2000_Db = new string[] { "Collation", "CompatibilityLevel", "CreateDate", "ID", "IsAccessible", "IsFullTextEnabled", "IsSystemObject", "IsUpdateable", "LastBackupDate", "LastDifferentialBackupDate", "LastLogBackupDate", "Name", "Owner", "ReadOnly", "RecoveryModel", "ReplicationOptions", "Status", "Version" };
-        private static readonly string[] Fields200x_Db = new string[] { "Collation", "CompatibilityLevel", "CreateDate", "ID", "IsAccessible", "IsFullTextEnabled", "IsSystemObject", "IsUpdateable", "LastBackupDate", "LastDifferentialBackupDate", "LastLogBackupDate", "Name", "Owner", "ReadOnly", "RecoveryModel", "ReplicationOptions", "Status", "Version", "BrokerEnabled", "DatabaseSnapshotBaseName", "IsMirroringEnabled", "Trustworthy" };
-        private static readonly string[] Fields201x_Db = new string[] { "Collation", "CompatibilityLevel", "CreateDate", "ID", "IsAccessible", "IsFullTextEnabled", "IsSystemObject", "IsUpdateable", "LastBackupDate", "LastDifferentialBackupDate", "LastLogBackupDate", "Name", "Owner", "ReadOnly", "RecoveryModel", "ReplicationOptions", "Status", "Version", "BrokerEnabled", "DatabaseSnapshotBaseName", "IsMirroringEnabled", "Trustworthy", "ActiveConnections", "AvailabilityDatabaseSynchronizationState", "AvailabilityGroupName", "ContainmentType", "EncryptionEnabled" };
-
-        private static readonly string[] Fields2000_Login = new string[] { "CreateDate", "DateLastModified", "DefaultDatabase", "DenyWindowsLogin", "IsSystemObject", "Language", "LanguageAlias", "LoginType", "Name", "Sid", "WindowsLoginAccessType" };
-        private static readonly string[] Fields200x_Login = new string[] { "CreateDate", "DateLastModified", "DefaultDatabase", "DenyWindowsLogin", "IsSystemObject", "Language", "LanguageAlias", "LoginType", "Name", "Sid", "WindowsLoginAccessType", "AsymmetricKey", "Certificate", "Credential", "ID", "IsDisabled", "IsLocked", "IsPasswordExpired", "MustChangePassword", "PasswordExpirationEnabled", "PasswordPolicyEnforced" };
-        private static readonly string[] Fields201x_Login = new string[] { "CreateDate", "DateLastModified", "DefaultDatabase", "DenyWindowsLogin", "IsSystemObject", "Language", "LanguageAlias", "LoginType", "Name", "Sid", "WindowsLoginAccessType", "AsymmetricKey", "Certificate", "Credential", "ID", "IsDisabled", "IsLocked", "IsPasswordExpired", "MustChangePassword", "PasswordExpirationEnabled", "PasswordPolicyEnforced", "PasswordHashAlgorithm" };
-
-        //see #7753
-        private static readonly string[] Fields_Job = new string[] { "LastRunOutcome", "CurrentRunStatus", "CurrentRunStep", "CurrentRunRetryAttempt", "NextRunScheduleID", "NextRunDate", "LastRunDate", "JobType", "HasStep", "HasServer", "CurrentRunRetryAttempt", "HasSchedule", "Category", "CategoryID", "CategoryType", "OperatorToEmail", "OperatorToNetSend", "OperatorToPage" };
-
-        private static int _loadedSmoMajorVersion = -1;
-
-        private static int GetLoadedSmoMajorVersion()
-        {
-            // PS begin block: $loadedSmoVersion from the loaded Microsoft.SqlServer.SMO
-            // assembly's location/ProductVersion, later compared -ge 11. The compiled port
-            // links the vendored SMO directly (file version 18.x for SqlManagementObjects
-            // 181.x), so this resolves once and stays.
-            if (_loadedSmoMajorVersion < 0)
-            {
-                try
-                {
-                    string location = typeof(Server).Assembly.Location;
-                    System.Diagnostics.FileVersionInfo info = System.Diagnostics.FileVersionInfo.GetVersionInfo(location);
-                    _loadedSmoMajorVersion = info.ProductMajorPart;
-                }
-                catch
-                {
-                    // Single-file or reflection-restricted hosts: the linked SMO is modern.
-                    _loadedSmoMajorVersion = 18;
-                }
-            }
-            return _loadedSmoMajorVersion;
-        }
-
-        /// <summary>
-        /// The SetDefaultInitFields priming of Connect-DbaInstance.ps1, with the exact
-        /// per-version field lists (BP-201/BP-202).
-        /// </summary>
-        /// <param name="server">The connected server</param>
-        /// <param name="isAzure">Whether the target is Azure (skips priming)</param>
-        /// <param name="messageCallback">Optional verbatim-message sink</param>
-        public static void ApplyDefaultInitFields(Server server, bool isAzure, Action<MessageLevel, string> messageCallback)
-        {
-            // By default, SMO initializes several properties. We push it to the limit and gather a bit more
-            // this slows down the connect a smidge but drastically improves overall performance
-            // especially when dealing with a multitude of servers
-            if (GetLoadedSmoMajorVersion() >= 11 && !isAzure)
-            {
-                try
-                {
-                    if (messageCallback != null)
-                        messageCallback(MessageLevel.Debug, "SetDefaultInitFields will be used");
-                    StringCollection initFieldsDb = new StringCollection();
-                    StringCollection initFieldsLogin = new StringCollection();
-                    StringCollection initFieldsJob = new StringCollection();
-                    if (server.VersionMajor == 8)
-                    {
-                        // 2000
-                        initFieldsDb.AddRange(Fields2000_Db);
-                        initFieldsLogin.AddRange(Fields2000_Login);
-                    }
-                    else if (server.VersionMajor == 9 || server.VersionMajor == 10)
-                    {
-                        // 2005 and 2008
-                        initFieldsDb.AddRange(Fields200x_Db);
-                        initFieldsLogin.AddRange(Fields200x_Login);
-                    }
-                    else if (server.VersionMajor >= 16)
-                    {
-                        // 2022 and above - exclude ActiveConnections due to performance issue #9282
-                        foreach (string field in Fields201x_Db)
-                        {
-                            if (!String.Equals(field, "ActiveConnections", StringComparison.Ordinal))
-                                initFieldsDb.Add(field);
-                        }
-                        initFieldsLogin.AddRange(Fields201x_Login);
-                    }
-                    else
-                    {
-                        // 2012 to 2019
-                        initFieldsDb.AddRange(Fields201x_Db);
-                        initFieldsLogin.AddRange(Fields201x_Login);
-                    }
-                    server.SetDefaultInitFields(typeof(Microsoft.SqlServer.Management.Smo.Database), initFieldsDb);
-                    server.SetDefaultInitFields(typeof(Microsoft.SqlServer.Management.Smo.Login), initFieldsLogin);
-                    //see 7753
-                    initFieldsJob.AddRange(Fields_Job);
-                    server.SetDefaultInitFields(typeof(Microsoft.SqlServer.Management.Smo.Agent.Job), initFieldsJob);
-                }
-                catch (Exception ex)
-                {
-                    if (messageCallback != null)
-                        messageCallback(MessageLevel.Debug, String.Format("SetDefaultInitFields failed with {0}", ex.Message));
-                    // perhaps a DLL issue, continue going
-                }
-            }
-        }
-        #endregion SetDefaultInitFields priming
-
-        /// <summary>
-        /// private/functions/Add-ConnectionHashValue.ps1 parity over
-        /// ConnectionHost.ActiveConnections: non-pooled connections append to the entry's
-        /// list, pooled connections replace it.
-        /// </summary>
-        /// <param name="key">The connection string key</param>
-        /// <param name="value">The Server or SqlConnection to register</param>
-        /// <param name="messageCallback">Optional verbatim-message sink</param>
-        public static void RegisterConnection(string key, object value, Action<MessageLevel, string> messageCallback)
-        {
-            if (messageCallback != null)
-                messageCallback(MessageLevel.Debug, "Adding to connection hash");
-            if (String.IsNullOrEmpty(key) || value == null)
-                return;
-
-            // PS: if ($Value.ConnectionContext.NonPooledConnection -or $Value.NonPooledConnection)
-            // A Server exposes it through ConnectionContext; a bare SqlConnection has neither,
-            // which lands in the pooled/replace branch exactly like the PS member miss did.
-            bool nonPooled = false;
-            Server serverValue = value as Server;
-            if (serverValue != null)
-            {
-                try { nonPooled = serverValue.ConnectionContext.NonPooledConnection; }
-                catch { /* unreadable on some connection shapes; treat as pooled like the PS member miss */ }
-            }
-
-            lock (ConnectionHost.ActiveConnections)
-            {
-                if (nonPooled)
-                {
-                    List<object> entries;
-                    if (!ConnectionHost.ActiveConnections.TryGetValue(key, out entries) || entries == null)
-                    {
-                        entries = new List<object>();
-                        ConnectionHost.ActiveConnections[key] = entries;
-                    }
-                    entries.Add(value);
-                }
-                else
-                {
-                    List<object> single = new List<object>();
-                    single.Add(value);
-                    ConnectionHost.ActiveConnections[key] = single;
-                }
-            }
-        }
     }
 }

--- a/project/dbatools/Connection/NetworkCredentialSspiContextProvider.cs
+++ b/project/dbatools/Connection/NetworkCredentialSspiContextProvider.cs
@@ -22,6 +22,15 @@ namespace Dataplat.Dbatools.Connection
         private bool disposed;
 
         /// <summary>
+        /// The case-insensitive Windows principal ("domain\user" or "user") this provider
+        /// authenticates as. Password-free, safe to use as part of a registry/cache key.
+        /// </summary>
+        public string Principal
+        {
+            get { return principal; }
+        }
+
+        /// <summary>
         /// Creates a provider that authenticates with the supplied Windows credential.
         /// </summary>
         /// <param name="credential">The Windows credential used for Negotiate authentication.</param>

--- a/project/dbatools/dbatools.csproj
+++ b/project/dbatools/dbatools.csproj
@@ -7,9 +7,9 @@
     <Product>dbatools</Product>
     <Description>The dbatools PowerShell Module library</Description>
     <Copyright>Copyright © 2025</Copyright>
-    <AssemblyVersion>0.10.0.83</AssemblyVersion>
-    <FileVersion>0.10.0.83</FileVersion>
-    <Version>0.10.0.83</Version>
+    <AssemblyVersion>0.10.0.84</AssemblyVersion>
+    <FileVersion>0.10.0.84</FileVersion>
+    <Version>0.10.0.84</Version>
     <AssemblyName>dbatools</AssemblyName>
     <SkipFunctionsDepsCopy>false</SkipFunctionsDepsCopy>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
## Summary

Follow-up to #56, per [this review note](https://github.com/dataplat/dbatools.library/pull/56#issuecomment-5156696231).

To avoid a `ConnectionContext.Copy()` that silently drops the `SspiContextProvider` identity, #56 kept explicit-Windows-credential connections out of `ConnectionHost.ActiveConnections` entirely. That stopped the identity loss, but it also made those connections invisible to `Get-DbaConnectedInstance` and unreachable for `Disconnect-DbaInstance`.

The underlying reason skipping registration looked like the safe option was a key collision: an explicit Windows credential lives out-of-band on `SqlConnection.SspiContextProvider`, not in the connection string, so two identities against the same server/database land on the same dictionary key. This keys them apart instead.

- `NetworkCredentialSspiContextProvider` exposes a password-free `Principal` (`domain\user`).
- `ConnectionService.GetRegistryKey` builds `connectionString + "|sspi:" + principal` for provider-backed connections; everything else is unchanged.
- `RegisterConnection` registers provider-backed connections again, under that composite key.
- `Disconnect-DbaInstance` computes the same key for lookup and removal, so cleanup keeps working.
- `Get-DbaConnectedInstance` strips the `|sspi:...` suffix before masking, so it no longer falls into the "failed to mask the connection string" path.
- **Bonus fix found while implementing this**: `Connect-DbaInstance`'s own post-emission `RegisterInstanceForTepp` call copied `ConnectionContext` unconditionally — the same identity-loss-via-copy #56 was designed to prevent, just reached through the TEPP cache instead of `ActiveConnections`. Now gated on `UsesCredentialSspiProvider` the way `ConnectionService.Verify.cs` already gates it.
- Split `ConnectionService.Verify.cs` (455 lines, over the repo's 400-line budget as flagged in the #56 review) into `Verify` / `Registry` / `InitFields` partials.
- Version bump: assembly `0.10.0.83` → `0.10.0.84`, CSV package `1.1.17` → `1.1.18`.

## Verification

The commit was authored in a sandbox with no `dotnet` or `pwsh`, so it shipped with its test plan unchecked. Run now on Windows:

- `dotnet build project/dbatools.sln` — **0 C# errors**. The build does emit 9 `XmlDoc2CmdletDoc PS100` SMO-load errors, but `main` emits the identical 9 in the same fresh worktree, so they are environmental (a clean worktree has no SMO drop for the doc step), not from this branch.
- New tests, net8.0 — **4/4 passed**: `NetworkCredentialSspiProviderExposesPasswordFreePrincipal`, `GetRegistryKey_WithoutSspiProvider_ReturnsConnectionStringUnchanged`, `GetRegistryKey_WithSspiProvider_AppendsPrincipal`, `RegisterConnection_DifferentSspiIdentitiesDoNotCollide` (the collision regression test).
- Connection suite — **16/16 net8.0**, **50/50 net472**.

Not covered: no live SQL Server run with a real explicit Windows credential. The end-to-end "shows up in `Get-DbaConnectedInstance` again" claim rests on unit coverage of the keying logic, not on a lab connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
