### PR TITLE
Set-DbaPrivilege - Write secedit's working database to temp, not cwd

### DIFF
--- a/project/dbatools.computer/Commands/SetDbaPrivilegeCommand.cs
+++ b/project/dbatools.computer/Commands/SetDbaPrivilegeCommand.cs
@@ -51,7 +51,10 @@ $strSID = $objUser.Translate([System.Security.Principal.SecurityIdentifier])
 $strSID.Value
 }";
 
-    // The three Invoke-Command2 -Raw scriptblocks, verbatim from the PS source (comments included).
+    // The three Invoke-Command2 -Raw scriptblocks, verbatim from the PS source (comments
+    // included), except MainScript's /db path and CleanupScript's extra Remove-Item - see the
+    // secedit.sdb/.jfm fix note on CleanupScript below. The retired PS source (dbatools/private/
+    // retired/Set-DbaPrivilege.ps1) still carries the original bug; it is dead code, not shipping.
     private const string ExportScript = @"
                             $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""""); secedit /export /cfg $temp\secpolByDbatools.cfg > $NULL;
                         ";
@@ -198,10 +201,14 @@ $strSID.Value
                                         }
                                     }
                                 }
-                                $null = secedit /configure /cfg $tempfile /db secedit.sdb /areas USER_RIGHTS /overwrite /quiet
+                                $null = secedit /configure /cfg $tempfile /db $temp\secedit.sdb /areas USER_RIGHTS /overwrite /quiet
                             ";
 
-    private const string CleanupScript = @" $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""""); Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL ";
+    // secedit /configure /db resolves a bare filename against the process's current directory,
+    // not $temp - a relative "secedit.sdb" left secedit.sdb/.jfm wherever the caller's shell
+    // happened to be running. Point /db at $temp and clean up the database and its journal file
+    // alongside the exported cfg.
+    private const string CleanupScript = @" $temp = ([System.IO.Path]::GetTempPath()).TrimEnd(""""); Remove-Item $temp\secpolByDbatools.cfg -Force > $NULL; Remove-Item $temp\secedit.sdb, $temp\secedit.jfm -Force -ErrorAction SilentlyContinue > $NULL ";
 
     // PS begin block: $ComputerName = $ComputerName.ComputerName | Select-Object -Unique. The
     // variable keeps its [DbaInstanceParameter[]] type constraint, so the unique ComputerName


### PR DESCRIPTION
## Summary

Companion fix to dataplat/dbatools's PR for the same bug report: `Set-DbaPrivilege` leaves `secedit.sdb`/`secedit.jfm` behind in the current working directory.

`SetDbaPrivilegeCommand.cs`'s `MainScript` constant calls `secedit /configure /cfg $tempfile /db secedit.sdb /areas USER_RIGHTS /overwrite /quiet` - the same relative `/db` argument as the PowerShell source it was ported from. `secedit.exe` resolves a bare filename for `/db` against the process's current directory, not `$env:TEMP`, so the working database and its `.jfm` journal file leak into whatever directory the caller's shell was running in.

- `MainScript`: point `/db` at `$temp\secedit.sdb` (`$temp` is already set earlier in the same scriptblock).
- `CleanupScript`: remove `$temp\secedit.sdb` and `$temp\secedit.jfm` alongside the existing `secpolByDbatools.cfg` cleanup.

The retired PowerShell source (`dbatools/private/retired/Set-DbaPrivilege.ps1`) still carries the original bug, but it's dead code on the `libmigration` branch, not shipping - not touched here.

## Verification

- `dotnet build dbatools.sln -c Debug` compiles `dbatools.computer` cleanly with this change (verified both with and without the patch to confirm a pre-existing, unrelated `XmlDoc2CmdletDoc` post-build failure in a fresh worktree - missing SMO assembly resolution on net8.0, across many unrelated projects - is not caused by this change; the actual `dbatools.computer.dll` output for both net472 and net8.0 built successfully).
- No dedicated MSTest coverage exists for `SetDbaPrivilegeCommand` currently, so none was added here; the behavioral regression test lives in the PowerShell repo's `tests/Set-DbaPrivilege.Tests.ps1`.
- Could not exercise this end-to-end locally - `secedit.exe` requires Administrator rights for a localhost target and my shell isn't elevated.

## Test plan

- [x] `dotnet build dbatools.sln -c Debug` succeeds for `dbatools.computer` (both target frameworks)
- [ ] Elevated integration run confirms no `secedit.sdb`/`secedit.jfm` leak into cwd

🤖 Generated with [Claude Code](https://claude.com/claude-code)